### PR TITLE
Fix deployment issue whilst NODE_ENV=production

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "react"
   ],
   "dependencies": {
+    "@types/autoprefixer": "^9.7.2",
+    "autoprefixer": "^9.7.5",
     "classnames": "^2.2.6",
     "date-fns": "^2.11.1",
     "dotenv": "^8.2.0",
@@ -50,18 +52,21 @@
     "gatsby-source-github-api": "^0.2.0",
     "gatsby-transformer-remark": "^2.7.1",
     "gatsby-transformer-sharp": "^2.4.4",
+    "lost": "^8.3.1",
+    "node-sass": "^4.13.1",
     "normalize-scss": "^7.0.1",
+    "postcss-pxtorem": "^5.1.1",
     "prismjs": "^1.20.0",
     "react": "^16.13.1",
     "react-disqus-comments": "^1.4.0",
     "react-dom": "^16.13.1",
-    "react-helmet": "^5.2.1"
+    "react-helmet": "^5.2.1",
+    "ts-node": "^8.8.2"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
-    "@types/autoprefixer": "^9.7.2",
     "@types/classnames": "^2.2.10",
     "@types/jest": "^25.2.1",
     "@types/node": "^12.12.34",
@@ -70,7 +75,6 @@
     "@types/react-test-renderer": "^16.9.2",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
-    "autoprefixer": "^9.7.5",
     "babel-jest": "^25.2.6",
     "babel-preset-gatsby": "^0.3.1",
     "eslint": "^6.8.0",
@@ -87,12 +91,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.2.7",
     "jest-cli": "^25.2.7",
-    "lost": "^8.3.1",
-    "node-sass": "^4.13.1",
-    "postcss-pxtorem": "^5.1.1",
     "prettier": "^2.0.2",
     "react-test-renderer": "^16.13.1",
-    "ts-node": "^8.8.2",
     "typescript": "^3.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10853,9 +10853,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
-  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
 


### PR DESCRIPTION
- Correctly split Node devdependencies and dependencies to make sure build still works whilst NODE_ENV=production 